### PR TITLE
Add Plonk functions

### DIFF
--- a/curves/bn254/icicle.go
+++ b/curves/bn254/icicle.go
@@ -35,7 +35,7 @@ func NttOnDevice(scalars_out, scalars_d, twiddles_d, coset_powers_d unsafe.Point
 }
 
 func MsmOnDevice(scalars_d, points_d unsafe.Pointer, count int, convert bool) (bn254.G1Jac, unsafe.Pointer, error) {
-	pointBytes := fp.Bytes * 3  // 3 Elements because of 3 coordinates
+	pointBytes := fp.Bytes * 3 // 3 Elements because of 3 coordinates
 	out_d, _ := goicicle.CudaMalloc(pointBytes)
 
 	icicle.Commit(out_d, scalars_d, points_d, count, 10)
@@ -51,7 +51,7 @@ func MsmOnDevice(scalars_d, points_d unsafe.Pointer, count int, convert bool) (b
 }
 
 func MsmG2OnDevice(scalars_d, points_d unsafe.Pointer, count int, convert bool) (bn254.G2Jac, unsafe.Pointer, error) {
-	pointBytes := fp.Bytes * 6  // 6 Elements because of 3 coordinates each with real and imaginary elements
+	pointBytes := fp.Bytes * 6 // 6 Elements because of 3 coordinates each with real and imaginary elements
 	out_d, _ := goicicle.CudaMalloc(pointBytes)
 
 	icicle.CommitG2(out_d, scalars_d, points_d, count, 10)
@@ -74,7 +74,7 @@ func ReverseScalars(ptr unsafe.Pointer, size int) error {
 	if success, err := icicle.ReverseScalars(ptr, size); success != 0 {
 		return err
 	}
-	
+
 	return nil
 }
 
@@ -101,5 +101,13 @@ func MontConvOnDevice(scalars_d unsafe.Pointer, size int, is_into bool) {
 		icicle.ToMontgomery(scalars_d, size)
 	} else {
 		icicle.FromMontgomery(scalars_d, size)
+	}
+}
+
+func VecMulOnDevice(scalars_a, scalars_d unsafe.Pointer, size int) {
+	ret := icicle.VecScalarMulMod(scalars_a, scalars_d, size)
+
+	if ret != 0 {
+		fmt.Print("Vector mul issue")
 	}
 }

--- a/curves/bn254/utils.go
+++ b/curves/bn254/utils.go
@@ -9,7 +9,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
 	goicicle "github.com/ingonyama-zk/icicle/goicicle"
 	icicle "github.com/ingonyama-zk/icicle/goicicle/curves/bn254"
-	"golang.org/x/sync/errgroup"
 )
 
 func CopyToDevice(scalars []fr.Element, bytes int, copyDone chan unsafe.Pointer) {
@@ -32,19 +31,13 @@ func CopyPointsToDevice(points []bn254.G1Affine, pointsBytes int, copyDone chan 
 	}
 }
 
-// TODO find better way to handle
 func CopyScalarsToHost(a_device unsafe.Pointer, n int, sizeBytes int) []fr.Element {
 	outHost := make([]fr.Element, n)
 
-	G := new(errgroup.Group)
-	G.Go(func() (err error) {
-		ret := goicicle.CudaMemCpyDtoH[fr.Element](outHost, a_device, sizeBytes)
-		if ret != 0 {
-			err = fmt.Errorf("Memory copy error")
-		}
-		return
-	})
-	G.Wait()
+	ret := goicicle.CudaMemCpyDtoH[fr.Element](outHost, a_device, sizeBytes)
+	if ret != 0 {
+		fmt.Print("Memory copy error")
+	}
 
 	return outHost
 }


### PR DESCRIPTION
This pull request adds support for copying scalars from device to host, and for batch multiple for scalars.  

Reason:  Keep icicle functions outside of gnark/plonk codebase.